### PR TITLE
[Feat/11] API 응답 통일, 공통 에러 처리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	// implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.11'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/mindreport/server/base/ApiResponse.java
+++ b/src/main/java/com/mindreport/server/base/ApiResponse.java
@@ -1,0 +1,34 @@
+package com.mindreport.server.base;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.mindreport.server.base.code.BaseCode;
+import com.mindreport.server.base.code.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonPropertyOrder("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode(), SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result) {
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
+        return new ApiResponse<>(false, code, message, data);
+    }
+}
+

--- a/src/main/java/com/mindreport/server/base/code/BaseCode.java
+++ b/src/main/java/com/mindreport/server/base/code/BaseCode.java
@@ -1,0 +1,8 @@
+package com.mindreport.server.base.code;
+
+public interface BaseCode {
+
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/mindreport/server/base/code/BaseErrorCode.java
+++ b/src/main/java/com/mindreport/server/base/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com.mindreport.server.base.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/mindreport/server/base/code/ErrorReasonDTO.java
+++ b/src/main/java/com/mindreport/server/base/code/ErrorReasonDTO.java
@@ -1,0 +1,21 @@
+package com.mindreport.server.base.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private final HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess() {
+        return isSuccess;
+    }
+
+}

--- a/src/main/java/com/mindreport/server/base/code/ReasonDTO.java
+++ b/src/main/java/com/mindreport/server/base/code/ReasonDTO.java
@@ -1,0 +1,20 @@
+package com.mindreport.server.base.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess() {
+        return isSuccess;
+    }
+}

--- a/src/main/java/com/mindreport/server/base/code/status/ErrorStatus.java
+++ b/src/main/java/com/mindreport/server/base/code/status/ErrorStatus.java
@@ -1,0 +1,46 @@
+package com.mindreport.server.base.code.status;
+
+import com.mindreport.server.base.code.BaseErrorCode;
+import com.mindreport.server.base.code.ErrorReasonDTO;
+import com.mindreport.server.base.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 가장 일반적인 에러
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+
+    // 테스트
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}
+

--- a/src/main/java/com/mindreport/server/base/code/status/SuccessStatus.java
+++ b/src/main/java/com/mindreport/server/base/code/status/SuccessStatus.java
@@ -1,0 +1,37 @@
+package com.mindreport.server.base.code.status;
+
+import com.mindreport.server.base.code.BaseCode;
+import com.mindreport.server.base.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }}

--- a/src/main/java/com/mindreport/server/base/exception/ExceptionAdvice.java
+++ b/src/main/java/com/mindreport/server/base/exception/ExceptionAdvice.java
@@ -1,0 +1,117 @@
+package com.mindreport.server.base.exception;
+
+import com.mindreport.server.base.ApiResponse;
+import com.mindreport.server.base.code.ErrorReasonDTO;
+import com.mindreport.server.base.code.status.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatus status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+    }
+
+    @org.springframework.web.bind.annotation.ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY, ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason, HttpHeaders headers, HttpServletRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
+//        e.printStackTrace();
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}
+

--- a/src/main/java/com/mindreport/server/base/exception/GeneralException.java
+++ b/src/main/java/com/mindreport/server/base/exception/GeneralException.java
@@ -1,0 +1,21 @@
+package com.mindreport.server.base.exception;
+
+import com.mindreport.server.base.code.BaseErrorCode;
+import com.mindreport.server.base.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/com/mindreport/server/base/exception/handler/TempHandler.java
+++ b/src/main/java/com/mindreport/server/base/exception/handler/TempHandler.java
@@ -1,0 +1,10 @@
+package com.mindreport.server.base.exception.handler;
+
+import com.mindreport.server.base.code.BaseErrorCode;
+import com.mindreport.server.base.exception.GeneralException;
+
+public class TempHandler extends GeneralException {
+    public TempHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/mindreport/server/controller/TestController.java
+++ b/src/main/java/com/mindreport/server/controller/TestController.java
@@ -1,5 +1,7 @@
 package com.mindreport.server.controller;
 
+import com.mindreport.server.base.code.status.ErrorStatus;
+import com.mindreport.server.base.exception.handler.TempHandler;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,4 +20,11 @@ public class TestController {
     public String hello() {
         return "Swagger Setting Success!";
     }
+
+    @GetMapping("/test/error")
+    @Operation(summary = "에러 통일 테스트용 API 입니다.", description = "simple API for API Error Response!")
+    public String apiResponseTest() {
+        throw new TempHandler(ErrorStatus.TEMP_EXCEPTION);
+    }
+
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요. -->
API 응답 통일 및 공통 에러 처리 구현


## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- build.gradle에 validation 의존성 추가
- 공통 응답을 위한 ApiResponse 클래스 추가
- 공통 에러 처리를 위한 커스텀 에러 및 exceptionAdvice 추가
- 공통 응답 테스트용 API 추가

## ⏳ 작업 내용
- [ ] API 응답 통일
- [ ] 공통 에러 처리 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
